### PR TITLE
Generalise output formatters

### DIFF
--- a/slack_bot/templates.py
+++ b/slack_bot/templates.py
@@ -1,0 +1,11 @@
+SONG_STATS_TEMPLATE = """
+*Song Details:*
+🎵 {title} by {artists}
+💿 {album} | 👤 {user_name} | 🕒 {message_time}
+🔗 {message_link}
+
+*Rating Stats:*
+⭐ Average Rating: {average_rating} ({reaction_count} reactions)
+👥 User Ratings:
+{user_ratings}
+"""


### PR DESCRIPTION
Created a generic function for formatting output.

Introduced `format_stats_messages` which takes a dictionary to populate/hydrate a template. This way we can define templates for each message type (song stats, user stats, etc) and move these out to a templates file.

#3 